### PR TITLE
Graph for number of citations

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,7 +272,10 @@ layout = dbc.Container(
                                     ]
                                 ),
                                 dbc.Col(
-                                        [citations_graph_diffusivity]
+                                        [
+                                            dcc.RadioItems(['Total', 'Per year'], 'Total', id="radio_citations_diffusivity", inline=True, inputStyle={"margin-left": "20px"}),
+                                            citations_graph_diffusivity
+                                            ]
                                     )
                                 ]
                             )
@@ -425,7 +428,10 @@ layout = dbc.Container(
                                     ]
                                 ),
                             dbc.Col(
-                                    [citations_graph_solubility]
+                                    [
+                                        dcc.RadioItems(['Total', 'Per year'], 'Total', id="radio_citations_solubility", inline=True, inputStyle={"margin-left": "20px"}),
+                                        citations_graph_solubility
+                                        ]
                                 )]
                         )
                     ],
@@ -480,6 +486,7 @@ app.layout = layout
 @app.callback(
     dash.Output("graph_nb_citations_diffusivity", "figure"),
     dash.Input("graph_diffusivity", "figure"),
+    dash.Input("radio_citations_diffusivity", "value"),
     dash.State("material_filter_diffusivities", "value"),
     dash.State("isotope_filter_diffusivities", "value"),
     dash.State("author_filter_diffusivities", "value"),
@@ -487,6 +494,7 @@ app.layout = layout
 )
 def make_figure(
         figure,
+        radio_citations_diffusivity,
         material_filter_diffusivities,
         isotope_filter_diffusivities,
         author_filter_diffusivities,
@@ -497,11 +505,16 @@ def make_figure(
         isotopes=isotope_filter_diffusivities,
         years=year_filter_diffusivities,
     )
-    return make_citations_graph(diffusitivites)
+    if radio_citations_diffusivity == "Per year":
+        per_year = True
+    else:
+        per_year = False
+    return make_citations_graph(diffusitivites, per_year)
 
 @app.callback(
     dash.Output("graph_nb_citations_solubility", "figure"),
     dash.Input("graph_solubilities", "figure"),
+    dash.Input("radio_citations_solubility", "value"),
     dash.State("material_filter_solubilities", "value"),
     dash.State("isotope_filter_solubilities", "value"),
     dash.State("author_filter_solubilities", "value"),
@@ -509,6 +522,7 @@ def make_figure(
 )
 def make_figure(
         figure,
+        radio_citations_solubility,
         material_filter_solubilities,
         isotope_filter_solubilities,
         author_filter_solubilities,
@@ -519,7 +533,11 @@ def make_figure(
         isotopes=isotope_filter_solubilities,
         years=year_filter_solubilities,
     )
-    return make_citations_graph(solubilities)
+    if radio_citations_solubility == "Per year":
+        per_year = True
+    else:
+        per_year = False
+    return make_citations_graph(solubilities, per_year)
 
 
 @app.callback(

--- a/app.py
+++ b/app.py
@@ -15,6 +15,8 @@ from graph import (
     make_figure_prop_per_year
 )
 
+from citations import citations_graph_diffusivity, citations_graph_solubility, make_citations_graph
+
 import h_transport_materials as htm
 
 from export import create_data_as_dict, generate_python_code
@@ -252,7 +254,8 @@ layout = dbc.Container(
                             ]
                         ),
                         dbc.Row(
-                            dbc.Col(
+                            [
+                                dbc.Col(
                                     [
                                         dcc.Graph(
                                             id="graph_prop_per_year_diffusivity",
@@ -267,7 +270,11 @@ layout = dbc.Container(
                                             style={"width": "100vh", "height": "50vh"},
                                         ),
                                     ]
-                                )
+                                ),
+                                dbc.Col(
+                                        [citations_graph_diffusivity]
+                                    )
+                                ]
                             )
                     ],
                 ),
@@ -401,7 +408,7 @@ layout = dbc.Container(
                             ]
                         ),
                         dbc.Row(
-                            dbc.Col(
+                            [dbc.Col(
                                     [
                                         dcc.Graph(
                                             id="graph_prop_per_year_solubility",
@@ -417,6 +424,9 @@ layout = dbc.Container(
                                         ),
                                     ]
                                 ),
+                            dbc.Col(
+                                    [citations_graph_solubility]
+                                )]
                         )
                     ],
                 ),
@@ -465,6 +475,51 @@ layout = dbc.Container(
     fluid=True,
 )
 app.layout = layout
+
+
+@app.callback(
+    dash.Output("graph_nb_citations_diffusivity", "figure"),
+    dash.Input("graph_diffusivity", "figure"),
+    dash.State("material_filter_diffusivities", "value"),
+    dash.State("isotope_filter_diffusivities", "value"),
+    dash.State("author_filter_diffusivities", "value"),
+    dash.State("year_filter_diffusivities", "value"),
+)
+def make_figure(
+        figure,
+        material_filter_diffusivities,
+        isotope_filter_diffusivities,
+        author_filter_diffusivities,
+        year_filter_diffusivities):
+    diffusitivites = make_diffusivities(
+        materials=material_filter_diffusivities,
+        authors=author_filter_diffusivities,
+        isotopes=isotope_filter_diffusivities,
+        years=year_filter_diffusivities,
+    )
+    return make_citations_graph(diffusitivites)
+
+@app.callback(
+    dash.Output("graph_nb_citations_solubility", "figure"),
+    dash.Input("graph_solubilities", "figure"),
+    dash.State("material_filter_solubilities", "value"),
+    dash.State("isotope_filter_solubilities", "value"),
+    dash.State("author_filter_solubilities", "value"),
+    dash.State("year_filter_solubilities", "value"),
+)
+def make_figure(
+        figure,
+        material_filter_solubilities,
+        isotope_filter_solubilities,
+        author_filter_solubilities,
+        year_filter_solubilities):
+    solubilities = make_solubilities(
+        materials=material_filter_solubilities,
+        authors=author_filter_solubilities,
+        isotopes=isotope_filter_solubilities,
+        years=year_filter_solubilities,
+    )
+    return make_citations_graph(solubilities)
 
 
 @app.callback(

--- a/citations.py
+++ b/citations.py
@@ -1,0 +1,44 @@
+import plotly.graph_objects as go
+from dash import dcc
+
+import h_transport_materials as htm
+
+def make_citations_graph(group: htm.PropertiesGroup):
+    references = []
+    nb_citations = []
+    for prop in group:
+        author = prop.author
+        year = prop.year
+
+        label = "{} ({})".format(author.capitalize(), year)
+        if label not in references:
+
+            references.append(label)
+            nb_citations.append(prop.nb_citations)
+
+    # sort values
+    references = [val_y for _, val_y in sorted(zip(nb_citations, references))]
+    nb_citations = sorted(nb_citations)
+
+    bar = go.Bar(
+            x=nb_citations,
+            y=references,
+            orientation='h')
+    fig = go.Figure(bar)
+    fig.update_xaxes(title="Number of citations (Crossref)")
+    return fig
+
+
+citations_graph_diffusivity = dcc.Graph(
+    id="graph_nb_citations_diffusivity",
+    figure=go.Figure(),
+    # style={"width": "100vh", "height": "50vh"},
+)
+
+citations_graph_solubility = dcc.Graph(
+    id="graph_nb_citations_solubility",
+    figure=go.Figure(),
+    # style={"width": "100vh", "height": "50vh"},
+)
+
+

--- a/citations.py
+++ b/citations.py
@@ -3,7 +3,7 @@ from dash import dcc
 
 import h_transport_materials as htm
 
-def make_citations_graph(group: htm.PropertiesGroup):
+def make_citations_graph(group: htm.PropertiesGroup, per_year: bool=True):
     references = []
     nb_citations = []
     for prop in group:
@@ -14,7 +14,10 @@ def make_citations_graph(group: htm.PropertiesGroup):
         if label not in references:
 
             references.append(label)
-            nb_citations.append(prop.nb_citations)
+            if per_year:
+                nb_citations.append(prop.nb_citations/(2022-year))
+            else:
+                nb_citations.append(prop.nb_citations)
 
     # sort values
     references = [val_y for _, val_y in sorted(zip(nb_citations, references))]
@@ -25,7 +28,11 @@ def make_citations_graph(group: htm.PropertiesGroup):
             y=references,
             orientation='h')
     fig = go.Figure(bar)
-    fig.update_xaxes(title="Number of citations (Crossref)")
+    if per_year:
+        x_label = "Average number of citations per year (Crossref)"
+    else:
+        x_label = "Number of citations (Crossref)"
+    fig.update_xaxes(title=x_label)
     return fig
 
 

--- a/export.py
+++ b/export.py
@@ -7,13 +7,17 @@ def create_data_as_dict(group: htm.PropertiesGroup):
     data = {}
     for property in group:
         name = "{}_{}_{}".format(property.isotope, property.author, property.year)
+        if property.bibsource:
+            source = property.bibdata.to_string('bibtex')
+        else:
+            source = property.source
         data_prop = {
             "pre_exp": property.pre_exp,
             "act_energy": property.act_energy,
             "year": property.year,
             "author": property.author,
             "isotope": property.isotope,
-            "source": property.source,
+            "source": source,
         }
         data[name] = data_prop
     return json.dumps(data, indent=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-h-transport-materials==0.3.0
+h-transport-materials==0.4.0
 numpy>=1.9
 dash==2.4.1
 dash-bootstrap-components==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-h-transport-materials==0.2.1
+h-transport-materials==0.3.0
 numpy>=1.9
 dash==2.4.1
 dash-bootstrap-components==1.1.0


### PR DESCRIPTION
This PR adds a graph to the tabs showing the number of citations for all the references displayed on the graph (based on the filters).

A radio button allows users to switch from absolute values (total citations) to relative values (average citations per year).

Thanks @Lili-Gigi for the suggestion!

This was made possible by [release 0.4.0 of HTM](https://github.com/RemDelaporteMathurin/h-transport-materials/releases/tag/v0.4.0) adding bibtex features.

The extract data button now exports the source key as bibtex string if possible.

![image](https://user-images.githubusercontent.com/40028739/172144302-2b7baeb7-4193-4be0-b7cf-bccaeaf060da.png)

![image](https://user-images.githubusercontent.com/40028739/172144689-d5f6b594-5444-4f27-8421-c8d31da21f28.png)
